### PR TITLE
Sensible defaults for request principal.

### DIFF
--- a/smith-cli.cabal
+++ b/smith-cli.cabal
@@ -31,6 +31,7 @@ executable smith
     , crypto-pubkey-openssh == 0.2.*
     , crypto-pubkey-types == 0.4.*
     , directory == 1.*
+    , exceptions == 0.10.*
     , filepath == 1.*
     , HsOpenSSL == 0.11.*
     , network == 2.*

--- a/src/Smith/Cli/Command/Issue.hs
+++ b/src/Smith/Cli/Command/Issue.hs
@@ -32,6 +32,7 @@ import           Smith.Client.Data.Environment (Environment (..))
 
 import qualified System.Posix.Process as Posix
 
+
 -- |
 -- Requests a certificate, registering it with ssh-agent if possible.
 --

--- a/src/Smith/Cli/Configuration.hs
+++ b/src/Smith/Cli/Configuration.hs
@@ -5,11 +5,19 @@
 module Smith.Cli.Configuration (
     Configuration (..)
   , configure
+  , configureDefaultPrincipal
   ) where
+
+import qualified Control.Monad.Catch as Catch
+
+import qualified Data.Text as Text
+
+import           Smith.Client.Data.CertificateRequest (Principal (..))
 
 import qualified System.Directory as Directory
 import qualified System.Environment as Environment
 import           System.FilePath (FilePath, (</>))
+import qualified System.Posix.User as User
 
 
 data Configuration =
@@ -25,6 +33,20 @@ configure = do
       (Configuration <$> defaultSmithHome)
       (pure . Configuration)
 
+configureDefaultPrincipal :: IO Principal
+configureDefaultPrincipal =
+  let
+    fallback =
+      maybe "root" id <$>
+        Environment.lookupEnv "USER"
+    current =
+      Catch.handleIOError (\_ -> fallback) $
+        (User.getLoginName)
+    override =
+      Environment.lookupEnv "SMITH_PRINCIPAL"
+  in
+    fmap (Principal . Text.pack) $
+      override >>= maybe current pure
 
 defaultSmithHome :: IO FilePath
 defaultSmithHome =

--- a/src/Smith/Cli/Dispatch.hs
+++ b/src/Smith/Cli/Dispatch.hs
@@ -21,6 +21,7 @@ import qualified Options.Applicative as Options
 --
 -- On parser success, the value will be returned.
 --
+-- FUTURE: Write a sensible multi-path command render.
 dispatch :: Options.Parser a -> IO a
 dispatch parser = do
   Options.customExecParser
@@ -30,4 +31,8 @@ dispatch parser = do
       ])
     (Options.info
       (parser <**> Options.helper)
-      Options.idm)
+      (mconcat [
+          Options.fullDesc
+        , Options.progDesc "Request temporary access using Smith."
+        , Options.header "Smith secure access requests."
+        ]))


### PR DESCRIPTION
 - Allows override via $SMITH_PRINCIPAL.
 - If not set, falls back to getlogin(2) to obtain current user.
 - If that fails, falls back to $USER.
 - If that is not set, falls back to 'root'.

Fixes #5.